### PR TITLE
Update to 1 8 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To contribute translations, check out our [guidelines](CONTRIBUTING.md).
 
 ## Brunch version
 
-This guide was written against Brunch 1.7.20.  Most of it likely works in earlier 1.7.x versions, but may need updates when the upcoming 1.8 or 2.0 gets out (especially WRT npm / `node_modules` integration).
+This guide was written against Brunch 1.8.3.  Most of it works in earlier 1.7.x versions, though; still, you should upgrade!
 
 ## License
 

--- a/content/en/chapter03-conventions-and-defaults.md
+++ b/content/en/chapter03-conventions-and-defaults.md
@@ -72,7 +72,7 @@ This is a must-have for sane debugging.
 
 Brunch can, out of the box, watch your files and trees in order to **automagically update the build** when changes are detected.  This update is **incremental and super-fast**.  Brunch will log a detailed message telling you what source files changed, what target files got updated, and how long this all took.
 
-Do note that watching is not always 100% reliable, though, usually on Windows, more rarely on Linux or OSX (this is true as of 1.7.20; the next release should have improved things in this regard).  A couple settings can help reduce what rare faux-pas you could see, we’ll explore these later.
+Do note that watching is not always 100% reliable, though, usually on Windows, more rarely on Linux or OSX (this was true as of 1.7.20; 1.8+ should have improved things in this regard).  A couple settings can help reduce what rare faux-pas you could see, we’ll explore these later.
 
 This watching happens when you use the `brunch watch` command instead of the one-shot `brunch build`.
 

--- a/content/en/chapter04-starting-from-scratch.md
+++ b/content/en/chapter04-starting-from-scratch.md
@@ -111,7 +111,7 @@ $ npm ls -depth=0
 simple-brunch@0.1.0 …
 ├── brunch@1.8.3
 ├── javascript-brunch@1.7.1
-└── sass-brunch@1.8.9
+└── sass-brunch@1.8.10
 ```
 
 Finally, we need a minimal **Brunch configuration**.  A Brunch configuration file is just a Node module that exports a `config` property; that property has at least a `files` property that describes concatenations.  Here’s our `brunch-config.coffee`:

--- a/content/en/chapter04-starting-from-scratch.md
+++ b/content/en/chapter04-starting-from-scratch.md
@@ -109,7 +109,7 @@ $ npm install --save-dev brunch javascript-brunch sass-brunch
 
 $ npm ls -depth=0
 simple-brunch@0.1.0 …
-├── brunch@1.7.20
+├── brunch@1.8.3
 ├── javascript-brunch@1.7.1
 └── sass-brunch@1.8.9
 ```

--- a/content/en/chapter05-using-third-party-registries.md
+++ b/content/en/chapter05-using-third-party-registries.md
@@ -25,7 +25,7 @@ We can then install jQuery like so:
 $ bower install --save jquery#1.*
 …
 
-jquery#1.11.2 bower_components/jquery
+jquery#1.11.3 bower_components/jquery
 ```
 
 This command looks up the Bower registry for the latest jQuery version in the 1.x range, installs it in the proper local directory, and updates `bower.json` to reflect the newly installed component.

--- a/content/en/chapter09-watcher.md
+++ b/content/en/chapter09-watcher.md
@@ -14,7 +14,7 @@ $ brunch watch    # Or brunch w, for the lazy…
 26 Feb 16:47:14 - info: compiled main.scss into app.css in 71ms
 ```
 
-Brunch has made significant changes in 1.7.0 to its internal watcher engine, `chokidar`, and now uses a **minimal check interval** to lighten the load even more.  By default, this interval is **65ms**.  If I wanted to be aggressive about it, I could set `fileListInterval` to `20`, for instance, and get this:
+Brunch has made significant changes in 1.7.0 and then again in 1.8.0 to its internal watcher engine, `chokidar`, and now uses a **minimal check interval** to lighten the load even more.  By default, this interval is **65ms**.  If I wanted to be aggressive about it, I could set `fileListInterval` to `20`, for instance, and get this:
 
 ```sh
 26 Feb 16:49:31 - info: compiled 3 files into 3 files, copied index.html in 266ms
@@ -184,7 +184,7 @@ $ ls -lah public/*.{js,css}
 
 Aaaah, [much better](https://www.youtube.com/watch?v=mvwd13F_1Gs).
 
-Be careful though, the current `chokidar` (in Brunch 1.7.x) seems to sometimes have trouble on Windows with detecting new files, occasionally even changes to known files.  I’ve also seen it happen a couple times on Linux or even OSX.  This should go away with upcoming 1.8, but in the meantime, I find switching `watcher.usePolling` to `true` alleviates most of this issue.
+Be careful though, `chokidar` (in Brunch 1.7.x) seemed to sometimes have trouble on Windows with detecting new files, occasionally even changes to known files.  I’ve also seen it happen a couple times on Linux or even OSX.  This should go away starting with 1.8.0, but in the meantime, I find switching `watcher.usePolling` to `true` alleviates most of this issue.
 
 ----
 

--- a/content/en/chapter10-web-server.md
+++ b/content/en/chapter10-web-server.md
@@ -29,15 +29,19 @@ This is great already, but sometimes you’ll need **a few more features**, if o
 
 We’ll keep it simple and use good ol’ [Express](http://expressjs.com/), with the minimum set of modules we need to achieve this.
 
-You let Brunch know about your custom server through the `server.path` setting, that will contain the path of your **module**.  This module must **export a `startServer(…)` function** with the following signature:
+By default, Brunch will look for a `brunch-server.coffee` or `brunch-server.js` file for your custom server module, but you can use a different path with the `server.path` setting.
+
+This module must **directly export a function** (default export, using `module.exports = `) with the following signature:
 
 ```javascript
-startServer(port, path, callback)
+yourFunction(port, path, callback)
 ```
+
+Before Brunch 1.8, you had to export a `startServer` method on your exported object.  This still works, but you should go the simpler way now and export your function directly as the module’s default export.
 
 When your server is up and ready ([to serve](http://www.thanatosrealms.com/war2/sounds/humans/peasant/ready.wav), ha ha), it calls `callback()` so **Brunch can resume its work**.  The server is **automatically stopped** when Brunch’s watcher terminates.
 
-Here’s our example server.  I could have written it in CoffeeScript, but in order to remain readable by everyone, I went with vanilla JS.  I put this in a `custom-server.js` file.
+Here’s our example server.  I could have written it in CoffeeScript, but in order to remain readable by everyone, I went with vanilla JS.  I put this in the expected `brunch-server.js` file.
 
 ```javascript
 'use strict';
@@ -49,7 +53,7 @@ var logger     = require('morgan');
 var Path       = require('path');
 
 // Our server start function
-exports.startServer = function startServer(port, path, callback) {
+module.exports = function startServer(port, path, callback) {
   var app = express();
   var server = http.createServer(app);
 
@@ -92,7 +96,6 @@ Then we’ll let our `brunch-config.coffee` know about it, and make the server a
 
 ```coffeescript
 server:
-  path: 'custom-server.js'
   run: yes
 ```
 

--- a/content/en/chapter10-web-server.md
+++ b/content/en/chapter10-web-server.md
@@ -103,8 +103,7 @@ Let’s try watching:
 
 ```sh
 $ brunch w
-02 Mar 12:45:04 - info: starting custom server
-02 Mar 12:45:04 - info: custom server started, initializing watcher
+02 Mar 12:45:04 - info: application started on http://localhost:3333/
 02 Mar 12:45:04 - info: compiled 3 files into 3 files, copied index.html in 269ms
 ```
 

--- a/content/en/chapter12-writing-a-plugin.md
+++ b/content/en/chapter12-writing-a-plugin.md
@@ -20,15 +20,15 @@ Now that we have this nailed, where should we start?  A Brunch plugin is first a
 ```json
 {
   "name": "git-sha-brunch",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "peerDependencies": {
-    "brunch": "~1.7"
+    "brunch": "~1.8"
   }
 }
 ```
 
-The `peerDependencies` part is optional (it’s even on its way to deprecation), but I like it…  On the other hand, it’s been an informal convention that Brunch plugins should track the major and minor version numbers of the Brunch they’re compatible with.  So if you don’t try for compatibility below Brunch 1.7, your plugin version should start at 1.7, for instance.  Note that this conflicts with [semver](http://semver.org/), so the team is trying to figure out a better way to express plugin/core compatibility.
+The `peerDependencies` part is optional (it’s even on its way to deprecation), but I like it…  On the other hand, it’s been an informal convention that Brunch plugins should track the major and minor version numbers of the Brunch they’re compatible with.  So if you don’t try for compatibility below Brunch 1.8, your plugin version should start at 1.8, for instance.  Note that this conflicts with [semver](http://semver.org/), so the team is trying to figure out a better way to express plugin/core compatibility.
 
 Because we didn’t specify a `main` property in our package file, Node will assume that the module’s entry point file is `index.js`.  We also know that a Brunch plugin is a constructor with a `prototype` equipped with several specific properties, that we mentioned earlier in this chapter:
 
@@ -150,11 +150,11 @@ Here’s how to perform the link:
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "brunch": "^1.7.20",
+    "brunch": "^1.8.3",
     "jade-brunch": "^1.8.1",
     "javascript-brunch": "^1.7.1",
     "sass-brunch": "^1.8.9",
-    "git-sha-brunch": "^1.7.0"
+    "git-sha-brunch": "^1.8.0"
   }
 }
 ```

--- a/content/en/chapter12-writing-a-plugin.md
+++ b/content/en/chapter12-writing-a-plugin.md
@@ -34,6 +34,7 @@ Because we didn’t specify a `main` property in our package file, Node will ass
 
   * `brunchPlugin` must be `true`;
   * `type`, `extension` or `pattern` can be used to filter down the files that should trigger processing;
+  * `preCompile(…)` if you want to get something done before compilation proper starts;
   * `compile(…)`, `lint(…)` or `optimize(…)`, depending on what role your plugin has;
   * `onCompile(…)` if you want to be notified when the build is complete (even in watcher mode);
   * `teardown(…)` if you need to clean up when Brunch shuts down (e.g. stop an embedded server started by your constructor).

--- a/content/en/chapter12-writing-a-plugin.md
+++ b/content/en/chapter12-writing-a-plugin.md
@@ -154,7 +154,7 @@ Here’s how to perform the link:
     "brunch": "^1.8.3",
     "jade-brunch": "^1.8.1",
     "javascript-brunch": "^1.7.1",
-    "sass-brunch": "^1.8.9",
+    "sass-brunch": "^1.8.10",
     "git-sha-brunch": "^1.8.0"
   }
 }

--- a/content/fr/README.md
+++ b/content/fr/README.md
@@ -54,7 +54,7 @@ Ceci est une tentative de fournir un guide raisonnablement complet pour [Brunch]
 
 ## Version de Brunch
 
-Ce guide a été écrit pour Brunch 1.7.20.  Il devrait très bien fonctionner sur toute version 1.7.x, mais aura peut-être besoin d'ajustements pour les versions 1.8 ou 2.0 à venir (en particulier concernant l'intégration avec npm / `node_modules`).
+Ce guide a été écrit pour Brunch 1.8.3.  La majorité du contenu devrait fonctionner dans les versions 1.7.x précédentes, ceci dit ; quoi qu’il en soit, vous devriez mettre à jour !
 
 ## Licence
 

--- a/content/fr/chapter03-conventions-and-defaults.md
+++ b/content/fr/chapter03-conventions-and-defaults.md
@@ -72,7 +72,7 @@ Indispensable pour un débogage sain.
 
 Brunch est, de base, capable de surveiller vos fichiers et dossiers sources pour, en cas de modification, **mettre automatiquement à jour les fichiers produits**.  Cette mise à jour est **incrémentale et très performante**.  Brunch affiche un message détaillé sur les fichiers sources détectés, les fichiers finaux mis à jour, et le temps que ça a pris.
 
-Remarquez toutefois que cette surveillance n'est pas toujours parfaitement fiable sur Windows, et plus rarement Linux ou OSX (en tout cas jusqu'en 1.7.20 ; la prochaine version devrait avoir amélioré les choses).  Certains réglages permettent de réduire ces faux-pas éventuels à presque rien, nous y reviendrons.
+Remarquez toutefois que cette surveillance n'est pas toujours parfaitement fiable sur Windows, et plus rarement Linux ou OSX (en tout cas jusqu'en 1.7.20 ; les 1.8+ devraient avoir amélioré les choses).  Certains réglages permettent de réduire ces faux-pas éventuels à presque rien, nous y reviendrons.
 
 Cette surveillance a lieu en utilisant la commande `brunch watch` plutôt que le simple `brunch build`.
 

--- a/content/fr/chapter04-starting-from-scratch.md
+++ b/content/fr/chapter04-starting-from-scratch.md
@@ -109,7 +109,7 @@ $ npm install --save-dev brunch javascript-brunch sass-brunch
 
 $ npm ls -depth=0
 simple-brunch@0.1.0 …
-├── brunch@1.7.20
+├── brunch@1.8.3
 ├── javascript-brunch@1.7.1
 └── sass-brunch@1.8.9
 ```

--- a/content/fr/chapter04-starting-from-scratch.md
+++ b/content/fr/chapter04-starting-from-scratch.md
@@ -111,7 +111,7 @@ $ npm ls -depth=0
 simple-brunch@0.1.0 …
 ├── brunch@1.8.3
 ├── javascript-brunch@1.7.1
-└── sass-brunch@1.8.9
+└── sass-brunch@1.8.10
 ```
 
 Il nous faut à présent une **configuration Brunch** minimale.  Un fichier de configuration Brunch est un module Node qui exporte une propriété `config`, laquelle a, au minimum, besoin de la propriété `files` pour connaître les concaténations à effectuer.  Voici notre `brunch-config.coffee` :

--- a/content/fr/chapter05-using-third-party-registries.md
+++ b/content/fr/chapter05-using-third-party-registries.md
@@ -25,7 +25,7 @@ On installerait alors comme ceci :
 $ bower install --save jquery#1.*
 …
 
-jquery#1.11.2 bower_components/jquery
+jquery#1.11.3 bower_components/jquery
 ```
 
 Cette commande interroge le référentiel de Bower pour obtenir la version la plus récente de jQuery dans la tranche 1.x, l’installe dans le bon dossier local, et met à jour `bower.json` pour refléter le composant fraîchement installé.

--- a/content/fr/chapter09-watcher.md
+++ b/content/fr/chapter09-watcher.md
@@ -14,7 +14,7 @@ $ brunch watch    # Ou brunch w, pour les flemmasses
 26 Feb 16:47:14 - info: compiled main.scss into app.css in 71ms
 ```
 
-Brunch a modifié vers sa version 1.7.0 sa couche de surveillance interne, `chokidar`, et utilise désormais un **intervalle de vérification minimal** pour réduire la charge, et cet intervalle est par défaut à **65ms**.  Si je voulais la jouer agressif et réglais `fileListInterval` à `20`, par exemple, ça donnerait ça :
+Brunch a modifié vers sa version 1.7.0, et à nouveau dans sa 1.8.0, la couche de surveillance interne : `chokidar`.  Elle utilise désormais un **intervalle de vérification minimal** pour réduire la charge, et cet intervalle est par défaut à **65ms**.  Si je voulais la jouer agressif et réglais `fileListInterval` à `20`, par exemple, ça donnerait ça :
 
 ```sh
 $ brunch watch
@@ -185,7 +185,7 @@ $ ls -lah public/*.{js,css}
 
 Aaaah, *[much better](https://www.youtube.com/watch?v=mvwd13F_1Gs)*.
 
-Attention, il arrive hélas fréquemment sur Windows (notamment depuis cette mise à jour de `chokidar`, que j'ai évoquée plus haut) que les nouveaux fichiers soient mal détectés, voire que certaines modifs passent à la trappe.  Plus rarement, je l'ai vu arriver sur Linux voire OSX.  Il semble qu'activer le réglage `watcher.usePolling` (à `true`, donc) résolve la majorité de ces problèmes (mais pas tous…).  Ça devrait s'améliorer considérablement avec la 1.8 à venir…
+Attention, il arrive hélas fréquemment sur Windows (notamment depuis cette mise à jour de `chokidar` en 1.7.0, que j'ai évoquée plus haut) que les nouveaux fichiers soient mal détectés, voire que certaines modifs passent à la trappe.  Plus rarement, je l'ai vu arriver sur Linux voire OSX.  Il semble qu'activer le réglage `watcher.usePolling` (à `true`, donc) résolve la majorité de ces problèmes (mais pas tous…).  La 1.8.0 devrait avoir considérablement amélioré ça…
 
 ----
 

--- a/content/fr/chapter10-web-server.md
+++ b/content/fr/chapter10-web-server.md
@@ -29,11 +29,15 @@ Il n’empêche, parfois votre micro-serveur a besoin de **fonctionnalités en p
 
 Nous allons rester simples et utiliser ce bon vieux [Express](http://expressjs.com/), avec le minimum de modules pour fournir notre service.
 
-On fournit un serveur personnalisé à Brunch en renseignant le réglage `server.path`, qui indique un **module** à vous.  Ce module doit **exporter une fonction `startServer(…)`** avec la signature suivante :
+Par défaut, Brunch va détecter un fichier `brunch-server.coffee` ou `brunch-server.js` pour votre **module** de serveur personnalisé.  Vous pouvez toutefois préciser un autre chemin avec le réglage `server.path`.
+
+Ce module doit **exporter une fonction directement** (export par défaut, avec `module.exports = `) dont la signature sera la suivante :
 
 ```js
-startServer(port, path, callback)
+yourFunction(port, path, callback)
 ```
+
+Avant Brunch 1.8, vous deviez exporter une méthode `startServer` sur l’objet d’export.  Ça marche toujours, mais vous devriez adopter la nouvelle approche et exporter la fonction directement comme export par défaut du module.
 
 Lorsque votre serveur a fini de démarrer, il appelle `callback()` pour que **Brunch reprenne la main**.  Le serveur est **automatiquement arrêté** quand le *watcher* de Brunch s’arrête.
 
@@ -49,7 +53,7 @@ var logger     = require('morgan');
 var Path       = require('path');
 
 // Notre fonction de démarrage serveur
-exports.startServer = function startServer(port, path, callback) {
+module.exports = function startServer(port, path, callback) {
   var app = express();
   var server = http.createServer(app);
 
@@ -93,7 +97,6 @@ Puis on modifie notre configuration, en rendant le serveur automatique tant qu�
 
 ```coffeescript
 server:
-  path: 'custom-server.js'
   run: yes
 ```
 

--- a/content/fr/chapter10-web-server.md
+++ b/content/fr/chapter10-web-server.md
@@ -104,8 +104,7 @@ Tentez un *watcher* :
 
 ```sh
 $ brunch w
-02 Mar 12:45:04 - info: starting custom server
-02 Mar 12:45:04 - info: custom server started, initializing watcher
+02 Mar 12:45:04 - info: application started on http://localhost:3333/
 02 Mar 12:45:04 - info: compiled 3 files into 3 files, copied index.html in 269ms
 ```
 

--- a/content/fr/chapter12-writing-a-plugin.md
+++ b/content/fr/chapter12-writing-a-plugin.md
@@ -154,7 +154,7 @@ Voici comment faire :
     "brunch": "^1.8.3",
     "jade-brunch": "^1.8.1",
     "javascript-brunch": "^1.7.1",
-    "sass-brunch": "^1.8.9",
+    "sass-brunch": "^1.8.10",
     "git-sha-brunch": "^1.8.0"
   }
 }

--- a/content/fr/chapter12-writing-a-plugin.md
+++ b/content/fr/chapter12-writing-a-plugin.md
@@ -34,6 +34,7 @@ Comme on n'a pas précisé de champ `main`, Node supposera que notre point d'ent
 
   * `brunchPlugin`, qui doit valoir `true` ;
   * `type`, `extension` ou `pattern` pour pouvoir être consulté au fil de la compilation ;
+  * `preCompile(…)` si on veut exécuter un traitement avant le début de la compilation proprement dite ;
   * `compile(…)`, `lint(…)` ou `optimize(…)`, suivant le rôle ;
   * `onCompile(…)` si on veut n'être notifié qu'en fin de build (même si c'est du *watcher*)
   * `teardown(…)` si on doit faire du nettoyage lorsque Brunch s'arrête (par exemple arrêter un serveur qu'on aurait lancé dans le constructeur).

--- a/content/fr/chapter12-writing-a-plugin.md
+++ b/content/fr/chapter12-writing-a-plugin.md
@@ -20,15 +20,15 @@ Sur cette base, comment procéder ?  Un plugin Brunch est avant tout **un modul
 ```json
 {
   "name": "git-sha-brunch",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "peerDependencies": {
-    "brunch": "~1.7"
+    "brunch": "~1.8"
   }
 }
 ```
 
-La partie `peerDependencies` n'est pas obligatoire (elle est même en phase de dépréciation), mais bon…  En revanche, il est communément admis que les plugins Brunch suivent les numéros de versions majeur et mineur du Brunch à partir duquel ils sont compatibles.  Donc si vous ne testez pas en-dessous de 1.7 par exemple, assurez-vous que votre version à vous démarre bien par 1.7.  Remarquez que ça entre en conflit direct avec le *semantic versioning* ([semver](http://semver.org/lang/fr/)), du coup l’équipe de Brunch est en train de réfléchir à une meilleure manière d’exprimer la compatibilité entre le noyau et les plugins.
+La partie `peerDependencies` n'est pas obligatoire (elle est même en phase de dépréciation), mais bon…  En revanche, il est communément admis que les plugins Brunch suivent les numéros de versions majeur et mineur du Brunch à partir duquel ils sont compatibles.  Donc si vous ne testez pas en-dessous de 1.8 par exemple, assurez-vous que votre version à vous démarre bien par 1.8.  Remarquez que ça entre en conflit direct avec le *semantic versioning* ([semver](http://semver.org/lang/fr/)), du coup l’équipe de Brunch est en train de réfléchir à une meilleure manière d’exprimer la compatibilité entre le noyau et les plugins.
 
 Comme on n'a pas précisé de champ `main`, Node supposera que notre point d'entrée est un fichier `index.js`.  On sait qu'un plugin Brunch est un constructeur dont le `prototype` est doté de certaines propriétés, mentionnées plus haut dans cet article :
 
@@ -150,11 +150,11 @@ Voici comment faire :
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "brunch": "^1.7.20",
+    "brunch": "^1.8.3",
     "jade-brunch": "^1.8.1",
     "javascript-brunch": "^1.7.1",
     "sass-brunch": "^1.8.9",
-    "git-sha-brunch": "^1.7.0"
+    "git-sha-brunch": "^1.8.0"
   }
 }
 ```


### PR DESCRIPTION
In order to wrap up the guide for 1.8, just leaving out npm / node_modules integration as per #4, I just worked through the changelog (both formal and history-based) and tweaked the guide (both languages) accordingly.

@paulmillr and @es128 can either/both of you quickly peruse the changes and :+1: this?  Then we can merge, I can also merge a tiny typo-related outstanding PR #8 on the fresh `master` and then we can go about our release plan (we should probably create a distinct issue for that release plan, btw).
