### PR TITLE
On dit chiffrement numérique, pas cryptage digital

### DIFF
--- a/content/fr/chapter04-starting-from-scratch.md
+++ b/content/fr/chapter04-starting-from-scratch.md
@@ -134,7 +134,7 @@ $ brunch build
 25 Feb 17:07:20 - info: compiled 2 files into 2 files, copied index.html in 94ms
 ```
 
-Remarquez le temps de build pour ce one-shot : **94 millisecondes**.  Et je suis sur un disque crypté à la volée.
+Remarquez le temps de build pour ce one-shot : **94 millisecondes**.  Et je suis sur un disque chiffré à la volée.
 
 Voyons ce qui a été généré dans `public` :
 


### PR DESCRIPTION
Voilou un petit changement rapide.

![](http://i.imgur.com/zdGlr7b.gif)

> _On ne crypte pas un message, on le chiffre, puis on le déchiffre avec une clé.
> Bien que crypter n'existe pas, le verbe décrypter existe pour un cas spécifique : il s'agit en quelque sorte de déchiffrer sans connaître la clé de chiffrement._
> cf [Chiffrement Numérique](https://cryptage-digital.fr/#)
