### PR TITLE
Adds link to last two chapters

### DIFF
--- a/content/en/chapter12-writing-a-plugin.md
+++ b/content/en/chapter12-writing-a-plugin.md
@@ -1,5 +1,7 @@
 # Writing a Brunch plugin
 
+This is part of [The Brunch.io Guide](../../README.md).
+
 So the previous chapter listed quite a few cool plugins, but I’m sure you’re already thinking about the shiny new one you’d like to contribute, right?  Fear not, as I’m going to show you how to **write your own Brunch plugin**.
 
 Brunch recognizes several plugin categories: compilers, linters, optimizers…  It detects that category based on which predefined methods you implement.  Depending on that category, you’ll get called at various moments of the build cycle, and in specific environments, too.

--- a/content/en/chapter13-conclusion.md
+++ b/content/en/chapter13-conclusion.md
@@ -1,5 +1,7 @@
 # Conclusion
 
+This is part of [The Brunch.io Guide](../../README.md).
+
 And to think this whole guide was originally supposed to be a reasonably short article (say, 5–6 hours of writing)…  :joy:  But then I kept thinking “Oh dang, I’ve got to mention this and that too!”
 
 I hope you **enjoyed this guide**, and more importantly that it **tentalized you to try out Brunch** instead of your usual build tool, because in the vast majority of situations, it’ll be **simpler, faster, and overall nicer!**


### PR DESCRIPTION
While reading the guide I noticed the last two chapters were missing the link back to the overview.
