### PR TITLE
-p option no longer used, use -P instead

### DIFF
--- a/content/en/chapter10-web-server.md
+++ b/content/en/chapter10-web-server.md
@@ -17,7 +17,7 @@ If you want that server to **always run** when the watcher starts, you just need
 server: {run: true}
 ```
 
-If you want a **different port** than 3333, you can use the `-p` or `--port` CLI option, or the `server.port` setting.
+If you want a **different port** than 3333, you can use the `-P` or `--port` CLI option, or the `server.port` setting.
 
 ## Writing your custom server
 


### PR DESCRIPTION
Quoting the CLI output:

```
The `-p` option is no longer used to specify the port. Use `-P` instead...
```

We're using the `-p` flag for production build.
